### PR TITLE
create Documentation with MkDocs

### DIFF
--- a/docs/api-guide/renderers.md
+++ b/docs/api-guide/renderers.md
@@ -1,0 +1,17 @@
+Renderers
+=========
+
+In order to support a new `media_type` in _REST Framework_, it is needed to add a [renderer](http://www.django-rest-framework.org/api-guide/renderers/) to `renderer_classes`. So DRF PDF includes `PDFRenderer`.
+
+API Reference
+-------------
+
+### PDFRenderer
+
+Render PDF binary content.
+
+**.media_type**: `application/pdf`
+
+**.format**: `pdf`
+
+**.render_style**: `bynary`

--- a/docs/api-guide/responses.md
+++ b/docs/api-guide/responses.md
@@ -1,0 +1,24 @@
+Responses
+=========
+
+You can use a [Regular REST Framework's Response](http://www.django-rest-framework.org/api-guide/responses/) to create a PDF file response, but _DRF PDF_ includes `PDFResponse` as a nice way to do it and it also includes some PDF file metadata.
+
+Example:
+```python
+from rest_framework import status
+from drf_pdf.response import PDFResponse
+
+response = PDFResponse(
+    pdf=pdf,
+    file_name=pdf_id,
+    status=status.HTTP_200_OK
+)
+```
+
+Arguments:
+
+* `pdf`: A byte array with the PDF file content.
+
+* `file_name`: The default downloaded file name
+
+You can also include _REST Framework's_ [Response arguments](http://www.django-rest-framework.org/api-guide/responses/#response).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,96 @@
+Welcome to DRF PDF
+==================
+
+DRF PDF is a set of simple PDF utils for Django Rest Framework
+
+
+Requirements
+------------
+
+* Python (2.7, 3.4)
+* Django (1.5, 1.6, 1.7)
+
+
+Installation
+------------
+
+Install using `pip`
+
+```
+pip install drf-pdf
+```
+
+Add `drf_pdf` to your `INSTALLED_APPS` setting.
+
+```python
+INSTALLED_APPS = (
+    ...
+    'drf_pdf',
+)
+```
+
+Example
+-------
+
+```python
+# coding: utf - 8
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from drf_pdf.renderer import PDFRenderer
+
+from my_pdf_package import PDFGenerator
+
+
+class PDFHandler(APIView):
+
+    renderer_classes = (PDFRenderer, )
+
+    def get(self, request):
+        pdf = PDFGenerator('foo')
+        headers = {
+            'Content-Disposition': 'filename="foo.pdf"',
+            'Content-Length': len(pdf),
+        }
+
+        return Response(
+            pdf,
+            headers=headers,
+            status=status.HTTP_200_OK
+        )
+```
+
+With two or more `renderer_classes`
+
+```python
+# coding: utf - 8
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.renderers import JSONRenderer
+from rest_framework.views import APIView
+
+from drf_pdf.response import PDFResponse
+from drf_pdf.renderer import PDFRenderer
+
+from my_pdf_package import get_pdf
+
+
+class PDFHandler(APIView):
+
+    renderer_classes = (PDFRenderer, JSONRenderer)
+
+    def get(self, request, pdf_id):
+        pdf = get_pdf(pdf_id)
+        if not pdf:
+            return Response(
+                {'error': 'Not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        return PDFResponse(
+            pdf=pdf,
+            file_name=pdf_id,
+            status=status.HTTP_200_OK
+        )
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 Welcome to DRF PDF
 ==================
 
-DRF PDF is a set of simple PDF utils for Django Rest Framework
+DRF PDF is a set of simple PDF utils for [Django Rest Framework](http://www.django-rest-framework.org/)
 
 
 Requirements
@@ -94,3 +94,9 @@ class PDFHandler(APIView):
             status=status.HTTP_200_OK
         )
 ```
+
+API Guide
+---------
+
+* [Renderers](api-guide/renderers.md)
+* [Response](api-guide/responses.md)

--- a/drf_pdf/renderer.py
+++ b/drf_pdf/renderer.py
@@ -3,10 +3,17 @@ from rest_framework.renderers import BaseRenderer
 
 
 class PDFRenderer(BaseRenderer):
+    """
+    Renderer for PDF binary content
+    """
+
     media_type = 'application/pdf'
     format = 'pdf'
     charset = None
     render_style = 'binary'
 
     def render(self, data, media_type=None, renderer_context=None):
+        """
+        Return the PDF data as it is
+        """
         return data

--- a/drf_pdf/response.py
+++ b/drf_pdf/response.py
@@ -3,6 +3,14 @@ from rest_framework.response import Response
 
 
 class PDFResponse(Response):
+    """
+    DRF Response to render data as a PDF File
+
+    kwargs:
+        - pdf (byte array). The PDF file content.
+        - file_name (string). The default downloaded file name.
+    """
+
     def __init__(self, pdf, file_name, *args, **kwargs):
         headers = headers = {
             'Content-Disposition': 'filename="{}.pdf"'.format(file_name),

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,1 +1,3 @@
 site_name: DRF PDF
+site_description: Simple PDF utils for Django Rest Framework
+repo_url: https://github.com/drgarcia1986/drf-pdf

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,8 @@
 site_name: DRF PDF
 site_description: Simple PDF utils for Django Rest Framework
 repo_url: https://github.com/drgarcia1986/drf-pdf
+
+pages:
+    - ['index.md', 'Home']
+    - ['api-guide/renderers.md', 'API Guide', 'Renderers']
+    - ['api-guide/responses.md', 'API Guide', 'Responses']

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: DRF PDF

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ ipdb==0.8
 git+https://github.com/mverteuil/pytest-ipdb.git
 djangorestframework==3.0.5
 Django==1.7.5
+mkdocs==0.11.1


### PR DESCRIPTION
You can preview the documentation by installing *mkdocs* and executing: `mkdocs serve`.

When it is okay, we could publish it in *Read The Docs*, but without closing the PR yet. So that I can add the final documentation URL to the `README` and `mkdocs.yml`

This PR addresses issue #14.